### PR TITLE
mardizzone/revert node upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ contracts/BorValidatorSet.sol
 pids
 logs
 genesis.json
+
+.idea


### PR DESCRIPTION
Revert `node` upgrade changes as incompatible with `matic-contracts` for `stateSync` and `checkpoints`