### PR TITLE
Add stateSyncConfirmationDelay to genesis template

### DIFF
--- a/genesis-template.json
+++ b/genesis-template.json
@@ -18,6 +18,9 @@
       "jaipurBlock": 0,
       "delhiBlock": 0,
       "indoreBlock": 0,
+      "stateSyncConfirmationDelay": {
+        "0": 128
+      },
       "period": {
         {% for block in blocks %}{% if block === blocks[blocks.length -1] %}"{{block.number}}": {{block.time}}
         {% else %}"{{block.number}}": {{block.time}},{% endif %}


### PR DESCRIPTION
This PR adds the missing `stateSyncConfirmationDelay` field to genesis template. This is required while calculating state sync delay post Indore HF ([PIP-12](https://forum.polygon.technology/t/pip-12-time-based-statesync-confirmations-delay/11950)). 