### PR TITLE
Replace svm with solc-select

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    matrix:
+      solc_version: [ "0.5.17", "0.6.12" ]
     steps:
       - uses: actions/checkout@v3
       - name: Update Path
@@ -22,12 +24,16 @@ jobs:
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
-      - uses: dtolnay/rust-toolchain@nightly
-      - name: Install svm
+      - name: Install solc-select
         run: |
-          cargo install svm-rs
-          svm install 0.5.17
-          svm install 0.6.12
+          sudo apt update
+          sudo apt install python3 python3-pip -y
+          pip install solc-select
+      - name: Install Solidity Version
+        run: |
+          solc-select install ${{ matrix.solc_version }}
+          solc-select use ${{ matrix.solc_version }}
+          solc --version
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    matrix:
     steps:
       - uses: actions/checkout@v3
       - name: Update Path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     matrix:
-      solc_version: [ "0.5.17", "0.6.12" ]
     steps:
       - uses: actions/checkout@v3
       - name: Update Path
@@ -31,8 +30,9 @@ jobs:
           pip install solc-select
       - name: Install Solidity Version
         run: |
-          solc-select install ${{ matrix.solc_version }}
-          solc-select use ${{ matrix.solc_version }}
+          solc-select install 0.5.17
+          solc-select install 0.6.12
+          solc-select use 0.5.17
           solc --version
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/generate-genesis.js
+++ b/generate-genesis.js
@@ -29,7 +29,7 @@ program.parse(process.argv)
 async function compileContract(key, contractFile, contractName, solcVersion) {
   return new Promise((resolve, reject) => {
     const ls = spawn(
-      `svm use ${solcVersion} && solc --bin-runtime openzeppelin-solidity/=node_modules/openzeppelin-solidity/ /=/ ${contractFile}`,
+      `solc-select use ${solcVersion} && solc --bin-runtime openzeppelin-solidity/=node_modules/openzeppelin-solidity/ /=/ ${contractFile}`,
       { shell: true }
     )
 


### PR DESCRIPTION
`svm` was creating issues for `matic-cli` when creating remote devnets on `gcp`.
This PR replaces it with `solc-select` which has been proved to work with both docker and remote setups (see [this run](https://github.com/maticnetwork/matic-cli/actions/runs/13828737417/job/38688380814?pr=328))
